### PR TITLE
Fix margin on rotated strip for faceting. 

### DIFF
--- a/urban_theme_mac.R
+++ b/urban_theme_mac.R
@@ -233,7 +233,7 @@ theme_urban <- function(base_size = 12, base_family = "Lato") {
     
     strip.text.x = element_text(margin = margin(t = 4.5, b = 4.5)), 
     strip.text.y = element_text(angle = -90, 
-                                margin = margin(l = 4.5, r = 4.5)), 
+                                margin = margin(t = 4.5, b = 4.5)), 
     
     strip.placement = "inside",
     strip.placement.x =  NULL,

--- a/urban_theme_windows.R
+++ b/urban_theme_windows.R
@@ -235,7 +235,7 @@ theme_urban <- function(base_size = 12, base_family = "Lato") {
   
     strip.text.x = element_text(margin = margin(t = 4.5, b = 4.5)), 
     strip.text.y = element_text(angle = -90, 
-                                margin = margin(l = 4.5, r = 4.5)), 
+                                margin = margin(t = 4.5, b = 4.5)), 
     
     strip.placement = "inside",
     strip.placement.x =  NULL,


### PR DESCRIPTION
The rotation doesn't switch t/b margins to l/r. Emily Reimal discovered this issue when building a faceted calendar plot. 