### PR TITLE
Revise links to appropriately redirect users to new repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A guide to building R graphics at the Urban Institute can be found [here](http:/
 
 ## Urban Institute ggplot2 theme
 
-This version of the Urban Institute ggplot2 theme is entirely deprecated. Please use the R package [libary(urbnthemes)](https://github.com/UI-Research/urbnthemes). 
+This version of the Urban Institute ggplot2 theme is entirely deprecated. Please use the R package [libary(urbnthemes)](https://github.com/UrbanInstitute/urbnthemes). 
 
 ## R Theme Copyright and License 
 

--- a/urban_theme.R
+++ b/urban_theme.R
@@ -1,1 +1,1 @@
-message("urban_theme.R is deprecated. Consider using library(urbnthemes) instead: https://github.com/UI-Research/urbnthemes")
+message("urban_theme.R is deprecated. Consider using library(urbnthemes) instead: https://github.com/UrbanInstitute/urbnthemes")

--- a/urban_theme_mac.R
+++ b/urban_theme_mac.R
@@ -1,1 +1,1 @@
-message("urban_theme.R is deprecated. Consider using library(urbnthemes) instead: https://github.com/UI-Research/urbnthemes")
+message("urban_theme.R is deprecated. Consider using library(urbnthemes) instead: https://github.com/UrbanInstitute/urbnthemes")

--- a/urban_theme_windows.R
+++ b/urban_theme_windows.R
@@ -1,1 +1,1 @@
-message("urban_theme.R is deprecated. Consider using library(urbnthemes) instead: https://github.com/UI-Research/urbnthemes")
+message("urban_theme.R is deprecated. Consider using library(urbnthemes) instead: https://github.com/UrbanInstitute/urbnthemes")


### PR DESCRIPTION
Links went to UI-Research, and I received a question wondering where it went. Edited the links to go to UrbanInstitute.